### PR TITLE
Increase port timeout

### DIFF
--- a/lib/blinkchain/hal.ex
+++ b/lib/blinkchain/hal.ex
@@ -187,7 +187,7 @@ defmodule Blinkchain.HAL do
       {^port, {:data, {_, 'ERR: ' ++ response}}} -> {:error, to_string(response)}
       {^port, {:exit_status, exit_status}} -> raise "rpi_ws281x OS process died with status: #{inspect(exit_status)}"
     after
-      500 -> raise "timeout waiting for rpi_ws281x OS process to reply"
+      1000 -> raise "timeout waiting for rpi_ws281x OS process to reply"
     end
   end
 

--- a/lib/blinkchain/hal.ex
+++ b/lib/blinkchain/hal.ex
@@ -187,7 +187,7 @@ defmodule Blinkchain.HAL do
       {^port, {:data, {_, 'ERR: ' ++ response}}} -> {:error, to_string(response)}
       {^port, {:exit_status, exit_status}} -> raise "rpi_ws281x OS process died with status: #{inspect(exit_status)}"
     after
-      1000 -> raise "timeout waiting for rpi_ws281x OS process to reply"
+      3000 -> raise "timeout waiting for rpi_ws281x OS process to reply"
     end
   end
 


### PR DESCRIPTION
Consistently seeing:

```
** (exit) exited in: GenServer.call(Blinkchain.HAL, :render, 5000)
    ** (EXIT) an exception was raised:
        ** (RuntimeError) timeout waiting for rpi_ws281x OS process to reply
            (blinkchain) lib/blinkchain/hal.ex:190: Blinkchain.HAL.receive_from_port/1
            (blinkchain) lib/blinkchain/hal.ex:105: Blinkchain.HAL.handle_call/3
            (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
            (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
            (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
    (elixir) lib/gen_server.ex:989: GenServer.call/3
```

So timeout might need to be increased. Not sure if this is hardware dependant.